### PR TITLE
Handle RISC-V split LR/SC

### DIFF
--- a/common/defs/cache_consts.svh
+++ b/common/defs/cache_consts.svh
@@ -77,7 +77,7 @@
 `define INVACK_CNT_CALC_WIDTH   (`INVACK_CNT_WIDTH + 1)
 `define CACHE_ID_WIDTH          `MAX_N_L2_BITS
 `define LLC_COH_DEV_ID_WIDTH    `MAX_N_LLC_BITS
-
+`define BRESP_WIDTH 2
 //
 // L2
 //
@@ -350,6 +350,11 @@
 
 `define L2_LOOKUP 1'b0
 `define L2_LOOKUP_FWD 1'b1
+
+`define BRESP_OKAY 2'b00
+`define BRESP_EXOKAY 2'b01
+`define BRESP_SLVERR 2'b10
+`define BRESP_DECERR 2'b11
 
 //GF12 DEFINES
 `define GF12_SRAM_SIZE 512

--- a/common/defs/cache_types.svh
+++ b/common/defs/cache_types.svh
@@ -44,7 +44,7 @@ typedef logic[(`LLC_COH_DEV_ID_WIDTH-1):0]   llc_coh_dev_id_t;
 typedef logic[(`MAX_N_L2_BITS-1):0]		owner_t;
 typedef logic[(`MAX_N_L2-1):0]		sharers_t;
 typedef logic[(`DMA_BURST_LENGTH_BITS-1):0]  dma_length_t;
-
+typedef logic[(`BRESP_WIDTH-1):0]   bresp_t;
 // invalidate address
 typedef line_addr_t l2_inval_t;
 

--- a/l2/Makefile
+++ b/l2/Makefile
@@ -44,12 +44,16 @@ RTL_SRC += ../common/rtl/*.sv
 l2-sim: $(L2_TB) $(L2_COSIM_SRC) $(RTL_SRC) $(L2_SRC)
 	cp cache_cfg.svh ../systemc/common/caches/cache_cfg.hpp
 	sed -i 's/`/#/g' ../systemc/common/caches/cache_cfg.hpp
+	sed -i 's/BIG_ENDIAN/ENDIAN_BIG_ENDIAN/g' ../systemc/common/caches/cache_cfg.hpp
+	sed -i 's/LITTLE_ENDIAN/ENDIAN_LITTLE_ENDIAN/g' ../systemc/common/caches/cache_cfg.hpp
 	ncsc_run -DRTL_SIM $(INCDIR) $(FLAGS) $^
 	rm ../systemc/common/caches/cache_cfg.hpp
 
 l2-sim-gui: $(L2_TB) $(L2_COSIM_SRC) $(RTL_SRC) $(L2_SRC)
 	cp cache_cfg.svh ../systemc/common/caches/cache_cfg.hpp
 	sed -i 's/`/#/g' ../systemc/common/caches/cache_cfg.hpp
+	sed -i 's/BIG_ENDIAN/ENDIAN_BIG_ENDIAN/g' ../systemc/common/caches/cache_cfg.hpp
+	sed -i 's/LITTLE_ENDIAN/ENDIAN_LITTLE_ENDIAN/g' ../systemc/common/caches/cache_cfg.hpp
 	ncsc_run -DRTL_SIM $(INCDIR) $(FLAGS) -GUI $^
 	rm ../systemc/common/caches/cache_cfg.hpp
 

--- a/l2/rtl/l2_core.sv
+++ b/l2/rtl/l2_core.sv
@@ -21,7 +21,8 @@ module l2_core(
     input logic l2_flush_valid,
     input logic l2_flush_i,
     input logic l2_inval_ready,
-    
+    input logic l2_bresp_ready,
+
     l2_cpu_req_t.in l2_cpu_req_i,
     l2_fwd_in_t.in l2_fwd_in_i, 
     l2_rsp_in_t.in l2_rsp_in_i, 
@@ -35,8 +36,10 @@ module l2_core(
     output logic l2_flush_ready,
     output logic l2_inval_valid,
     output logic flush_done, 
+    output logic l2_bresp_valid,
     output l2_inval_t l2_inval,
-    
+    output bresp_t l2_bresp,
+
     l2_req_out_t.out l2_req_out,
     l2_rsp_out_t.out l2_rsp_out,
     l2_rd_rsp_t.out l2_rd_rsp 
@@ -63,6 +66,7 @@ module l2_core(
     logic l2_rsp_out_ready_int, l2_req_out_ready_int, l2_inval_ready_int, l2_rd_rsp_ready_int;
     logic l2_cpu_req_valid_int, l2_fwd_in_valid_int, l2_rsp_in_valid_int, l2_flush_valid_int; 
     logic l2_rsp_out_valid_int, l2_req_out_valid_int, l2_inval_valid_int, l2_rd_rsp_valid_int; 
+    logic l2_bresp_valid_int, l2_bresp_ready_int;
     logic decode_en, lookup_en, rd_mem_en;
     logic fwd_stall, fwd_stall_ended, ongoing_flush, set_conflict, evict_stall, ongoing_atomic, idle;
     logic set_cpu_req_conflict, set_fwd_in_stalled;
@@ -80,6 +84,7 @@ module l2_core(
     logic wr_req_invack_cnt, wr_req_tag, wr_en_put_reqs, wr_req_state_atomic, put_reqs_atomic; 
     logic wr_en_lines_buf, wr_en_tags_buf, wr_en_states_buf, wr_en_hprots_buf; 
     logic wr_rst, wr_en_state, wr_en_line, wr_en_evict_way, rd_en; 
+    logic ongoing_atomic_set_conflict_instr, set_ongoing_atomic_set_conflict_instr, clr_ongoing_atomic_set_conflict_instr;
     logic [2:0] reqs_op_code; 
     logic [`L2_SET_BITS:0] flush_set; 
     logic [`L2_WAY_BITS:0] flush_way; 
@@ -89,6 +94,7 @@ module l2_core(
     addr_t cpu_req_addr;
     mix_msg_t fwd_in_coh_msg; 
     l2_inval_t l2_inval_o;
+    bresp_t l2_bresp_o;
     l2_set_t set; 
     l2_set_t set_in;
     l2_way_t empty_way, way_hit, way_hit_next, way;

--- a/l2/rtl/l2_input_decoder.sv
+++ b/l2/rtl/l2_input_decoder.sv
@@ -54,6 +54,10 @@ module l2_input_decoder (
     addr_breakdown_t.out addr_br,
     line_breakdown_l2_t.out line_br_next,
     addr_breakdown_t.out addr_br_next 
+
+`ifdef LLSC
+    , input logic ongoing_atomic_set_conflict_instr
+`endif    
     ); 
 
     always_comb begin 
@@ -119,7 +123,11 @@ module l2_input_decoder (
                     flush_done = 1'b1; 
                 end 
             end else if ((l2_cpu_req_valid_int || set_conflict)  && !evict_stall 
-                                && (reqs_cnt != 0 || ongoing_atomic)) begin 
+                && (reqs_cnt != 0 || ongoing_atomic) 
+`ifdef LLSC
+                && !ongoing_atomic_set_conflict_instr
+`endif                
+                ) begin 
                 do_cpu_req_next = 1'b1;
                 if (!set_conflict) begin 
                     l2_cpu_req_ready_int = 1'b1; 

--- a/l2/rtl/l2_regs.sv
+++ b/l2/rtl/l2_regs.sv
@@ -38,11 +38,17 @@ module l2_regs (
     output logic fwd_stall, 
     output logic fwd_stall_ended, 
     output logic ongoing_atomic, 
-    output logic evict_stall, 
+    output logic evict_stall,
     output logic [`L2_SET_BITS:0] flush_set, 
     output logic [`L2_WAY_BITS:0] flush_way,
     output logic [`REQS_BITS-1:0] fwd_stall_i, 
     output logic [`REQS_BITS_P1-1:0] reqs_cnt 
+   
+`ifdef LLSC
+    , input logic clr_ongoing_atomic_set_conflict_instr,
+    input logic set_ongoing_atomic_set_conflict_instr,
+    output logic ongoing_atomic_set_conflict_instr
+`endif
     );
 
     always_ff @(posedge clk or negedge rst) begin 
@@ -143,6 +149,18 @@ module l2_regs (
             evict_stall <= 1'b1; 
         end
     end
+
+`ifdef LLSC
+    always_ff @(posedge clk or negedge rst) begin
+        if (!rst) begin
+            ongoing_atomic_set_conflict_instr <= 1'b0;
+        end else if (clr_ongoing_atomic_set_conflict_instr) begin
+            ongoing_atomic_set_conflict_instr <= 1'b0;
+        end else if (set_ongoing_atomic_set_conflict_instr) begin
+            ongoing_atomic_set_conflict_instr <= 1'b1;
+        end
+    end
+`endif
 
 endmodule
 

--- a/l2/rtl/l2_rtl_top.sv
+++ b/l2/rtl/l2_rtl_top.sv
@@ -34,7 +34,8 @@ module l2_rtl_top(
     input logic l2_flush_data,
     input logic l2_inval_ready,
     input logic l2_stats_ready,
-     
+    input logic l2_bresp_ready,
+
     output logic l2_cpu_req_ready,
     output logic l2_fwd_in_ready,
     output logic l2_rsp_in_ready,
@@ -56,7 +57,9 @@ module l2_rtl_top(
     output l2_inval_t l2_inval_data,
     output logic l2_stats_valid,
     output logic l2_stats_data,
-    output logic flush_done
+    output logic flush_done,
+    output logic l2_bresp_valid,
+    output bresp_t l2_bresp_data
     );
 
     l2_cpu_req_t l2_cpu_req_i();
@@ -98,6 +101,9 @@ module l2_rtl_top(
 
     l2_inval_t l2_inval; 
     assign l2_inval_data = l2_inval;
+    
+    bresp_t l2_bresp;
+    assign l2_bresp_data = l2_bresp;
 
 `ifdef STATS_ENABLE
     logic l2_stats; 

--- a/l2/sim/l2_wrap.cpp
+++ b/l2/sim/l2_wrap.cpp
@@ -62,6 +62,11 @@ void l2_wrapper_conv::thread_l2_inval_data_conv(){
     l2_inval.data.write(tmp);
 }
 
+void l2_wrapper_conv::thread_l2_bresp_data_conv(){
+    bresp_t tmp = l2_bresp_data_conv.read();
+    l2_bresp.data.write(tmp);
+}
+
 #ifdef STATS_ENABLE
 void l2_wrapper_conv::thread_l2_stats_data_conv(){
     bool tmp = l2_stats_data_conv.read();

--- a/l2/sim/l2_wrap.h
+++ b/l2/sim/l2_wrap.h
@@ -62,7 +62,11 @@ public:
     sc_in<bool> l2_inval_ready;
     sc_out<bool> l2_inval_valid;
     sc_out<l2_inval_t> l2_inval_data;
-   
+    
+    sc_in<bool> l2_bresp_ready;
+    sc_out<bool> l2_bresp_valid;
+    sc_out<bresp_t> l2_bresp_data;
+ 
     sc_out<bool> flush_done;
 
 #ifdef STATS_ENABLE
@@ -115,7 +119,10 @@ public:
     , l2_inval_ready("l2_inval_ready")
     , l2_inval_valid("l2_inval_valid")
     , l2_inval_data("l2_inval_data")
-    , flush_done("flush_done")
+    , l2_bresp_ready("l2_bresp_ready")
+    , l2_bresp_valid("l2_bresp_valid")
+    , l2_bresp_data("l2_bresp_data")
+, flush_done("flush_done")
 #ifdef STATS_ENABLE
         , l2_stats_valid ("l2_stats_valid")
         , l2_stats_data("l2_stats_data")
@@ -141,6 +148,7 @@ public:
     cynw::cynw_put_port_base<l2_rsp_out_t> l2_rsp_out;
     cynw::cynw_put_port_base<l2_rd_rsp_t> l2_rd_rsp;
     cynw::cynw_put_port_base<l2_inval_t> l2_inval;
+    cynw::cynw_put_port_base<bresp_t> l2_bresp;
 
 #ifdef STATS_ENABLE
     cynw::cynw_put_port_base<bool> l2_stats;
@@ -158,6 +166,7 @@ public:
     , l2_rsp_out("l2_rsp_out")
     , l2_rd_rsp("l2_rd_rsp")
     , l2_inval ("l2_inval")
+    , l2_bresp ("l2_bresp")
 #ifdef STATS_ENABLE
         ,  l2_stats("l2_stats")
 #endif          
@@ -185,6 +194,7 @@ public:
     , l2_rd_rsp_data_conv_line("l2_rd_rsp_data_conv_line")
     , l2_flush_data_conv("l2_flush_data_conv")
     , l2_inval_data_conv("l2_inval_data_conv")
+    , l2_bresp_data_conv("l2_bresp_data_conv")
 #ifdef STATS_ENABLE
         , l2_stats_data_conv("l2_stats_data_conv")
 #endif
@@ -207,6 +217,8 @@ public:
         sensitive << l2_rd_rsp_data_conv_line;
         SC_METHOD(thread_l2_inval_data_conv);
         sensitive << l2_inval_data_conv; 
+        SC_METHOD(thread_l2_bresp_data_conv);
+        sensitive << l2_bresp_data_conv; 
 #ifdef STATS_ENABLE
         SC_METHOD(thread_l2_stats_data_conv);
         sensitive << l2_stats_data_conv;
@@ -254,6 +266,9 @@ public:
     cosim.l2_inval_ready(l2_inval.ready);
     cosim.l2_inval_valid(l2_inval.valid);
     cosim.l2_inval_data(l2_inval_data_conv);
+    cosim.l2_bresp_ready(l2_bresp.ready);
+    cosim.l2_bresp_valid(l2_bresp.valid);
+    cosim.l2_bresp_data(l2_bresp_data_conv);
     cosim.flush_done(flush_done);
 #ifdef STATS_ENABLE
         cosim.l2_stats_valid (l2_stats.valid);
@@ -294,6 +309,8 @@ public:
     sc_signal<bool> l2_flush_data_conv;
    
     sc_signal<l2_inval_t> l2_inval_data_conv;
+    
+    sc_signal<bresp_t> l2_bresp_data_conv;
 #ifdef STATS_ENABLE
     sc_signal<bool> l2_stats_data_conv;
 #endif
@@ -307,6 +324,7 @@ public:
     void thread_l2_rsp_out_data_conv();
     void thread_l2_rd_rsp_data_conv();
     void thread_l2_inval_data_conv(); 
+    void thread_l2_bresp_data_conv(); 
 #ifdef STATS_ENABLE
     void thread_l2_stats_data_conv();
 #endif

--- a/l2/sim/system.hpp
+++ b/l2/sim/system.hpp
@@ -30,6 +30,7 @@ public:
     put_get_channel<l2_rsp_out_t> l2_rsp_out_chnl;
     put_get_channel<l2_rd_rsp_t> l2_rd_rsp_chnl;
     put_get_channel<l2_inval_t> l2_inval_chnl;
+    put_get_channel<bresp_t> l2_bresp_chnl;
 
 #ifdef STATS_ENABLE
     put_get_channel<bool> l2_stats_chnl;
@@ -59,6 +60,7 @@ public:
 	dut->l2_rsp_out(l2_rsp_out_chnl);
 	dut->l2_rd_rsp(l2_rd_rsp_chnl);
 	dut->l2_inval(l2_inval_chnl);
+	dut->l2_bresp(l2_bresp_chnl);
 #ifdef STATS_ENABLE
 	dut->l2_stats(l2_stats_chnl);
 #endif
@@ -74,6 +76,7 @@ public:
 	tb->l2_rsp_out_tb(l2_rsp_out_chnl);
 	tb->l2_rd_rsp_tb(l2_rd_rsp_chnl);
 	tb->l2_inval_tb(l2_inval_chnl);
+	tb->l2_bresp_tb(l2_bresp_chnl);
 #ifdef STATS_ENABLE
 	tb->l2_stats_tb(l2_stats_chnl);
 #endif

--- a/systemc/common/caches/cache_cfg.hpp
+++ b/systemc/common/caches/cache_cfg.hpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2011-2021 Columbia University, System Level Design Group
+// SPDX-License-Identifier: Apache-2.0
+#ifndef __CACHES_CFG_SVH__
+#define __CACHES_CFG_SVH__
+
+//set LITTLE_ENDIAN for Ariane, BIG_ENDIAN for Leon
+#define BIG_ENDIAN
+//3 for Ariane, 2 for Leon
+#define BYTE_BITS    2
+//1 for Ariane, 2 for Leon
+#define WORD_BITS    2
+#define L2_WAYS      4
+#define L2_SETS      1024
+
+#endif // __CACHES_CFG_SVH__

--- a/systemc/common/caches/cache_consts.hpp
+++ b/systemc/common/caches/cache_consts.hpp
@@ -77,7 +77,7 @@
 #define INVACK_CNT_CALC_WIDTH   (INVACK_CNT_WIDTH + 1)
 #define CACHE_ID_WIDTH          MAX_N_L2_BITS
 #define LLC_COH_DEV_ID_WIDTH    MAX_N_LLC_BITS
-
+#define BRESP_WIDTH 2
 //
 // L2
 //
@@ -134,6 +134,7 @@
 #define HIT		0
 #define MISS		1
 #define MISS_EVICT	2
+#define REG_WRITE_TO_ATOMIC 3
 
 // Invalidation acknowledges order
 #define DATA_FIRST	0
@@ -231,6 +232,11 @@
 #define RSP_EDATA	1
 #define RSP_INVACK	2
 #define RSP_DATA_DMA    3
+
+#define BRESP_OKAY 0
+#define BRESP_EXOKAY 1
+#define BRESP_SLVERR 2
+#define BRESP_DECERR 3
 
 // DMA burst
 #define DMA_BURST_LENGTH_BITS 32

--- a/systemc/common/caches/cache_types.hpp
+++ b/systemc/common/caches/cache_types.hpp
@@ -49,7 +49,7 @@ typedef sc_uint<LLC_COH_DEV_ID_WIDTH>   llc_coh_dev_id_t;
 typedef sc_uint<MAX_N_L2_BITS>		owner_t;
 typedef sc_uint<MAX_N_L2>		sharers_t;
 typedef sc_uint<DMA_BURST_LENGTH_BITS>  dma_length_t;
-
+typedef sc_uint<BRESP_WIDTH>    bresp_t;
 /*
  * L2 cache coherence channels types
  */

--- a/systemc/common/syn/caches.tcl
+++ b/systemc/common/syn/caches.tcl
@@ -32,28 +32,5 @@ set_attr sharing_effort_parts low
 set_attr sharing_effort_regs low
 
 
-if {$TECH eq "virtex7"} {
-    set CLOCK_PERIOD 12.5
-    set_attr default_input_delay      0.1
-}
-if {$TECH eq "zynq7000"} {
-    set CLOCK_PERIOD 10.0
-    set_attr default_input_delay      0.1
-}
-if {$TECH eq "virtexu"} {
-    set CLOCK_PERIOD 8.0
-    set_attr default_input_delay      0.1
-}
-if {$TECH eq "virtexup"} {
-    set CLOCK_PERIOD 6.4
-    set_attr default_input_delay      0.1
-}
-if {$TECH eq "cmos32soi"} {
-    set CLOCK_PERIOD 1000.0
-    set_attr default_input_delay      100.0
-}
-set_attr clock_period $CLOCK_PERIOD
-
-
 set CACHE_INCLUDES "-I../../common/caches"
 

--- a/systemc/l2/src/l2.hpp
+++ b/systemc/l2/src/l2.hpp
@@ -73,6 +73,7 @@ public:
     // Output ports
     put_initiator<l2_rd_rsp_t>	l2_rd_rsp;
     put_initiator<l2_inval_t>	l2_inval;
+    put_initiator<bresp_t>      l2_bresp;
     nb_put_initiator<l2_req_out_t> l2_req_out;
     nb_put_initiator<l2_rsp_out_t> l2_rsp_out;
 
@@ -111,6 +112,7 @@ public:
 	, l2_flush("l2_flush")
 	, l2_rd_rsp("l2_rd_rsp")
 	, l2_inval("l2_inval")
+        , l2_bresp("l2_bresp")
 	, l2_req_out("l2_req_out")
 	, l2_rsp_out("l2_rsp_out")
 #ifdef STATS_ENABLE
@@ -129,6 +131,7 @@ public:
 	    l2_flush.clk_rst (clk, rst);
 	    l2_rd_rsp.clk_rst(clk, rst);
 	    l2_inval.clk_rst(clk, rst);
+            l2_bresp.clk_rst (clk, rst);
 	    l2_req_out.clk_rst(clk, rst);
 	    l2_rsp_out.clk_rst(clk, rst);
 #ifdef STATS_ENABLE
@@ -164,6 +167,7 @@ public:
     /* Functions to send output messages */
     void send_rd_rsp(line_t lines);
     void send_inval(line_addr_t addr_inval);
+    void send_bresp(bresp_t resp);
     void send_req_out(coh_msg_t coh_msg, hprot_t hprot, line_addr_t line_addr, line_t lines);
     void send_rsp_out(coh_msg_t coh_msg, cache_id_t req_id, bool to_req, line_addr_t line_addr, line_t line);
 
@@ -214,6 +218,10 @@ private:
     sc_uint<REQS_BITS> reqs_atomic_i;
     bool ongoing_flush;
     uint32_t flush_way, flush_set;
+#ifdef LLSC
+    bool ongoing_atomic_set_conflict_instr;
+    line_addr_t ongoing_atomic_set_conflict_instr_line_addr;
+#endif
 };
 
 

--- a/systemc/l2/src/l2_directives.hpp
+++ b/systemc/l2/src/l2_directives.hpp
@@ -68,6 +68,11 @@
     // HLS_DEFINE_PROTOCOL("l2-send-inval-protocol")
     // bookmark_tmp |= BM_SEND_INVAL;			
 
+#define SEND_BRESP							\
+    if (RPT_RTL) CACHE_REPORT_TIME(sc_time_stamp(), "Send bresp.")
+    // HLS_DEFINE_PROTOCOL("l2-send-bresp-protocol")
+    // bookmark_tmp |= BM_SEND_BRESP;			
+
 #define SEND_RSP_OUT							\
     if (RPT_RTL) CACHE_REPORT_TIME(sc_time_stamp(), "Send rsp out.");   \
     HLS_DEFINE_PROTOCOL("l2-send-rsp-out-protocol")

--- a/systemc/l2/stratus/project.tcl
+++ b/systemc/l2/stratus/project.tcl
@@ -10,6 +10,34 @@
 #
 source ../../common/syn/caches.tcl
 
+#
+# Timing constraints
+#
+if {$TECH eq "virtex7"} {
+    set CLOCK_PERIOD 20.0
+    set_attr default_input_delay      0.1
+}
+if {$TECH eq "zynq7000"} {
+    set CLOCK_PERIOD 20.0
+    set_attr default_input_delay      0.1
+}
+if {$TECH eq "virtexu"} {
+    set CLOCK_PERIOD 12.8
+    set_attr default_input_delay      0.1
+}
+if {$TECH eq "virtexup"} {
+    set CLOCK_PERIOD 12.8
+    set_attr default_input_delay      0.1
+}
+if {$TECH eq "cmos32soi"} {
+    set CLOCK_PERIOD 1000.0
+    set_attr default_input_delay      100.0
+}
+if {$TECH eq "gf12"} {
+    set CLOCK_PERIOD 1000.0
+    set_attr default_input_delay      100.0
+}
+set_attr clock_period $CLOCK_PERIOD
 
 #
 # System level modules to be synthesized

--- a/systemc/l2/stratus/project.tcl
+++ b/systemc/l2/stratus/project.tcl
@@ -88,7 +88,7 @@ set_attr hls_cc_options "$INCLUDES $CACHE_INCLUDES"
 #
 # Simulation Options
 #
-use_systemc_simulator incisive
+use_systemc_simulator xcelium
 set_attr cc_options "$INCLUDES  $CACHE_INCLUDES -DCLOCK_PERIOD=$CLOCK_PERIOD"
 # enable_waveform_logging -vcd
 set_attr end_of_sim_command "make saySimPassed"

--- a/systemc/l2/stratus/project.tcl
+++ b/systemc/l2/stratus/project.tcl
@@ -29,11 +29,11 @@ define_system_module tb  ../tb/l2_tb.cpp ../tb/system.cpp ../tb/sc_main.cpp
 # set params_set(n) "sets ways word_off_bits byte_off_bits address_bits endian"
 
 # Leon3 default
-set params_set(0) "512 4 2 2 32 BIG_ENDIAN"
+set params_set(0) "512 4 2 2 32 BIG_ENDIAN NOLLSC"
 # Ariane default
-set params_set(1) "512 4 1 3 32 LITTLE_ENDIAN"
+set params_set(1) "512 4 1 3 32 LITTLE_ENDIAN LLSC"
 # Ibex default
-set params_set(2) "512 4 2 2 32 LITTLE_ENDIAN"
+set params_set(2) "512 4 2 2 32 LITTLE_ENDIAN NOLLSC"
 
 foreach ps [array names params_set] {
 
@@ -43,17 +43,18 @@ foreach ps [array names params_set] {
     set bbits  [lindex $params_set($ps) 3]
     set abits  [lindex $params_set($ps) 4]
     set endian [lindex $params_set($ps) 5]
+    set llsc   [lindex $params_set($ps) 6]
 
     set words_per_line [expr 1 << $wbits]
     set bits_per_word [expr (1 << $bbits) * 8]
 
     if {$endian == "BIG_ENDIAN"} {set endian_str "be"} {set endian_str "le"}
 
-    set pars "_${sets}SETS_${ways}WAYS_${words_per_line}x${bits_per_word}LINE_${abits}ADDR_${endian_str}"
+    set pars "_${sets}SETS_${ways}WAYS_${words_per_line}x${bits_per_word}LINE_${abits}ADDR_${llsc}_${endian_str}"
 
     set iocfg "IOCFG$pars"
 
-    define_io_config * $iocfg -DL2_SETS=$sets -DL2_WAYS=$ways -DADDR_BITS=$abits -DBYTE_BITS=$bbits -DWORD_BITS=$wbits -DENDIAN_$endian
+    define_io_config * $iocfg -DL2_SETS=$sets -DL2_WAYS=$ways -DADDR_BITS=$abits -DBYTE_BITS=$bbits -DWORD_BITS=$wbits -DENDIAN_$endian -D${llsc}
 
     define_system_config tb "TESTBENCH$pars" -io_config $iocfg
 

--- a/systemc/l2/tb/l2_tb.hpp
+++ b/systemc/l2/tb/l2_tb.hpp
@@ -33,6 +33,7 @@ public:
     // Output ports
     get_initiator<l2_rd_rsp_t>	l2_rd_rsp_tb;
     get_initiator<l2_inval_t>   l2_inval_tb;
+    get_initiator<bresp_t>   l2_bresp_tb;
     get_initiator<l2_req_out_t> l2_req_out_tb;
     get_initiator<l2_rsp_out_t> l2_rsp_out_tb;
 
@@ -67,6 +68,7 @@ public:
 	l2_flush_tb.clk_rst (clk, rst);
 	l2_rd_rsp_tb.clk_rst(clk, rst);
 	l2_inval_tb.clk_rst(clk, rst);
+	l2_bresp_tb.clk_rst(clk, rst);
 	l2_req_out_tb.clk_rst(clk, rst);
 	l2_rsp_out_tb.clk_rst(clk, rst);
 #ifdef STATS_ENABLE
@@ -100,6 +102,7 @@ public:
     void put_rsp_in(coh_msg_t coh_msg, addr_t addr, line_t line, invack_cnt_t invack_cnt);
     void get_rd_rsp(line_t line);
     void get_inval(addr_t addr);
+    void get_bresp(bresp_t gold_val);
     void op(cpu_msg_t cpu_msg, int beh, int rsp_beh, coh_msg_t rsp_msg, invack_cnt_t invack_cnt, 
 	    coh_msg_t put_msg, hsize_t hsize, addr_breakdown_t req_addr, word_t req_word, 
 	    line_t rsp_line, int fwd_beh, mix_msg_t fwd_msg, state_t fwd_state, cache_id_t fwd_id, 

--- a/systemc/l2/tb/system.hpp
+++ b/systemc/l2/tb/system.hpp
@@ -33,6 +33,7 @@ public:
     // From L2 cache
     put_get_channel<l2_rd_rsp_t>	l2_rd_rsp_chnl;
     put_get_channel<l2_inval_t>	        l2_inval_chnl;
+    put_get_channel<bresp_t>	        l2_bresp_chnl;
     put_get_channel<l2_req_out_t>	l2_req_out_chnl;
     put_get_channel<l2_rsp_out_t>	l2_rsp_out_chnl;
 
@@ -63,6 +64,7 @@ public:
 	dut->l2_flush(l2_flush_chnl);
 	dut->l2_rd_rsp(l2_rd_rsp_chnl);
 	dut->l2_inval(l2_inval_chnl);
+	dut->l2_bresp(l2_bresp_chnl);
 	dut->l2_req_out(l2_req_out_chnl);
 	dut->l2_rsp_out(l2_rsp_out_chnl);
 #ifdef STATS_ENABLE
@@ -79,6 +81,7 @@ public:
 	tb->l2_flush_tb(l2_flush_chnl); 
 	tb->l2_rd_rsp_tb(l2_rd_rsp_chnl);
 	tb->l2_inval_tb(l2_inval_chnl);
+	tb->l2_bresp_tb(l2_bresp_chnl);
 	tb->l2_req_out_tb(l2_req_out_chnl);
 	tb->l2_rsp_out_tb(l2_rsp_out_chnl);
 #ifdef STATS_ENABLE

--- a/systemc/llc/stratus/project.tcl
+++ b/systemc/llc/stratus/project.tcl
@@ -101,7 +101,7 @@ set_attr hls_cc_options "$INCLUDES $CACHE_INCLUDES"
 #
 # Simulation Options
 #
-use_systemc_simulator incisive
+use_systemc_simulator xcelium
 set_attr cc_options "$INCLUDES  $CACHE_INCLUDES -DCLOCK_PERIOD=$CLOCK_PERIOD"
 # enable_waveform_logging -vcd
 set_attr end_of_sim_command "make saySimPassed"

--- a/systemc/llc/stratus/project.tcl
+++ b/systemc/llc/stratus/project.tcl
@@ -11,6 +11,35 @@
 source ../../common/syn/caches.tcl
 
 #
+# Timing constraints
+#
+if {$TECH eq "virtex7"} {
+    set CLOCK_PERIOD 10.0
+    set_attr default_input_delay      0.1
+}
+if {$TECH eq "zynq7000"} {
+    set CLOCK_PERIOD 10.0
+    set_attr default_input_delay      0.1
+}
+if {$TECH eq "virtexu"} {
+    set CLOCK_PERIOD 8.0
+    set_attr default_input_delay      0.1
+}
+if {$TECH eq "virtexup"} {
+    set CLOCK_PERIOD 6.4
+    set_attr default_input_delay      0.1
+}
+if {$TECH eq "cmos32soi"} {
+    set CLOCK_PERIOD 1000.0
+    set_attr default_input_delay      100.0
+}
+if {$TECH eq "gf12"} {
+    set CLOCK_PERIOD 1000.0
+    set_attr default_input_delay      100.0
+}
+set_attr clock_period $CLOCK_PERIOD
+
+#
 # WORKAROUND. When the target FPGA is the Xilinx Ultrascale(+) we generate the LLC
 # as if the target FPGA was a Xilinx Virtex7 w/ clock period of 12.5 ns.
 # To do so here we overwrite two attributes.


### PR DESCRIPTION
This PR includes changes to the way atomic operations are handled by the private cache controller.

Specifically, we allow instruction fetch that miss in the processor L1 to be handled in the ESP L2 without terminating an ongoing atomic operation. Split LR/SC, in fact, are separate transactions on the AXI bus, which may be interleaved with requests from the instruction cache.

In addition, the PR adds a write acknowledge channel to the private cache interface (the AXI `bresp` channel). We use the `bresp` channel to acknowledge completion of the atomic operation. This corresponds to the write transaction of an atomic operation.

On the `bresp` channel we distinguish success of the atomic operation (`HRESP_EXOKAY`) from failure (`HRESP_OKAY`). The only atomic that can occasionally fail is LR/SC, because read and write operations may be interleaved with other data memory accesses on the bus. While LR/SC can fail, it is guaranteed that on subsequent attempts, it eventually succeeds, thus avoiding any deadlock condition.

We also added a configuration parameters to enable LR/SC based on the processor core architecture selected in ESP.